### PR TITLE
Set filename-friendly snapshot names

### DIFF
--- a/lib/snapshot_testing/rspec.rb
+++ b/lib/snapshot_testing/rspec.rb
@@ -7,7 +7,7 @@ module SnapshotTesting
     def self.included(base)
       base.let :__snapshot_recorder__ do |example|
         SnapshotTesting::Recorder.new(
-          name: example.description,
+          name: example.description.try(:parameterize),
           path: example.metadata[:absolute_file_path]
         )
       end


### PR DESCRIPTION
Not in all cases examples are named the way that the description can
immediately be used for as a snapshot filename. In our spec suite
e.g. there's been failures against 0.3.3 when specs are not specifically
named, but have an inferred name.

Chose to go with Rails' String#parameterize since we're using Rails
and it returns well readable strings when testing w/ a few of these
cases, but there might be a more general solution for everyone to use.

Original errors:
```
  1) Failure/Error: (snapshots.keys - visited).grep(/^#{name}\s\d+$/).length
  RegexpError:
    empty char-class: /^is expected to eq []\s\d+$/

  2) Failure/Error: (snapshots.keys - visited).grep(/^#{name}\s\d+$/).length
  RegexpError:
    empty range in char class: /^is expected to have received add_to_menus_catalog([{:caterer_city_names=>["Berlin"], ...]) 1 time\s\d+$/
```